### PR TITLE
Use Pair class of apache.commons.lang3 instead of javafx

### DIFF
--- a/rocketmq-streams-clients/src/main/java/org/apache/rocketmq/streams/client/transform/WindowStream.java
+++ b/rocketmq-streams-clients/src/main/java/org/apache/rocketmq/streams/client/transform/WindowStream.java
@@ -22,7 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
-import javafx.util.Pair;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.rocketmq.streams.client.transform.window.Time;
 import org.apache.rocketmq.streams.common.channel.builder.IChannelBuilder;
 import org.apache.rocketmq.streams.common.channel.sink.ISink;

--- a/rocketmq-streams-window/src/main/java/org/apache/rocketmq/streams/window/operator/AbstractWindow.java
+++ b/rocketmq-streams-window/src/main/java/org/apache/rocketmq/streams/window/operator/AbstractWindow.java
@@ -18,8 +18,8 @@ package org.apache.rocketmq.streams.window.operator;
 
 import com.alibaba.fastjson.JSONObject;
 
-import javafx.util.Pair;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.rocketmq.streams.common.channel.sink.ISink;
@@ -831,7 +831,7 @@ public abstract class AbstractWindow extends BasedConfigurable implements IAfter
                 for(IMessage message:messages){
                     JSONObject msg=message.getMessageBody();
                     try {
-                        msg=this.mapFunction.map(new Pair(windowInstance,msg));
+                        msg=this.mapFunction.map(Pair.of(windowInstance, msg));
                         Message copyMsg=new Message(msg);
                         copyMsg.getHeader().setQueueId(queueId);
                         copyMsg.getHeader().setOffset(message.getHeader().getOffset());


### PR DESCRIPTION
**问题描述：**

`rocketmq-streams`源码无法在Java 11环境编译。

**问题原因：**

源码中使用到的`javafx.util.Pair`类型在Java 11及之后版本中已移除。

**PullRequest内容：**

使用更通用的`org.apache.commons.lang3.tuple.Pair`类型替换`javafx.util.Pair`类型，经验证替换后项目可以在Java 11环境顺利编译使用。