### PR TITLE
[ISSUE #257]Use  thread name as rocksdb path

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -45,9 +45,11 @@
             <artifactId>rocksdbjni</artifactId>
             <version>7.6.0</version>
         </dependency>
-
-
-
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.11.0</version>
+        </dependency>
 
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/core/src/main/java/org/apache/rocketmq/streams/core/common/Constant.java
+++ b/core/src/main/java/org/apache/rocketmq/streams/core/common/Constant.java
@@ -48,7 +48,7 @@ public class Constant {
 
     public static final String WINDOW_END_TIME = "window_end_time";
 
-    public static final String WORKER_THREAD_NAME = "worker_thread";
+    public static final String WORKER_THREAD_NAME = "ROCKETMQ_STREAMS";
 
     public static final String STATIC_TOPIC_BROKER_NAME = "__syslo__global__";
 

--- a/core/src/main/java/org/apache/rocketmq/streams/core/running/WorkerThread.java
+++ b/core/src/main/java/org/apache/rocketmq/streams/core/running/WorkerThread.java
@@ -82,7 +82,7 @@ public class WorkerThread extends Thread {
         DefaultMQProducer producer = rocketMQClient.producer(groupName);
         DefaultMQAdminExt mqAdmin = rocketMQClient.getMQAdmin();
 
-        RocksDBStore rocksDBStore = new RocksDBStore();
+        RocksDBStore rocksDBStore = new RocksDBStore(threadName);
         RocketMQStore store = new RocketMQStore(producer, rocksDBStore, mqAdmin, this.properties);
 
         this.planetaryEngine = new PlanetaryEngine<>(unionConsumer, producer, store, mqAdmin, wrapper);

--- a/core/src/main/java/org/apache/rocketmq/streams/core/running/WorkerThread.java
+++ b/core/src/main/java/org/apache/rocketmq/streams/core/running/WorkerThread.java
@@ -99,7 +99,6 @@ public class WorkerThread extends Thread {
             logger.error("worker thread=[{}], error:{}.", this.getName(), e);
             throw new RStreamsException(e);
         } finally {
-            logger.info("worker thread=[{}], engin stopped.", this.getName());
             this.planetaryEngine.stop();
         }
     }
@@ -242,16 +241,21 @@ public class WorkerThread extends Thread {
             }
         }
 
-        public void stop() {
+        public synchronized void stop() {
+            if (this.stop) {
+                return;
+            }
+
             this.stop = true;
 
             try {
-                this.stateStore.close();
                 this.unionConsumer.shutdown();
                 this.producer.shutdown();
                 this.mqAdmin.shutdown();
+                this.stateStore.close();
             } catch (Throwable e) {
                 logger.error("error when stop engin.", e);
+                throw new RStreamsException(e);
             }
         }
     }

--- a/core/src/main/java/org/apache/rocketmq/streams/core/running/WorkerThread.java
+++ b/core/src/main/java/org/apache/rocketmq/streams/core/running/WorkerThread.java
@@ -105,7 +105,6 @@ public class WorkerThread extends Thread {
 
     public void shutdown() {
         this.planetaryEngine.stop();
-        logger.info("worker thread=[{}], shutdown task success, jobId:{}", this.getName(), jobId);
     }
 
 
@@ -253,6 +252,7 @@ public class WorkerThread extends Thread {
                 this.producer.shutdown();
                 this.mqAdmin.shutdown();
                 this.stateStore.close();
+                logger.info("shutdown engine success, thread:{}, jobId:{}", WorkerThread.this.getName(), jobId);
             } catch (Throwable e) {
                 logger.error("error when stop engin.", e);
                 throw new RStreamsException(e);

--- a/core/src/main/java/org/apache/rocketmq/streams/core/state/RocksDBStore.java
+++ b/core/src/main/java/org/apache/rocketmq/streams/core/state/RocksDBStore.java
@@ -29,6 +29,8 @@ import org.rocksdb.RocksDBException;
 import org.rocksdb.RocksIterator;
 import org.rocksdb.TtlDB;
 import org.rocksdb.WriteOptions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
@@ -37,6 +39,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class RocksDBStore extends AbstractStore implements AutoCloseable {
+    private static final Logger logger = LoggerFactory.getLogger(RocksDBStore.class);
+
     private static final String ROCKSDB_PATH = "/tmp/rocksdb";
     private RocksDB rocksDB;
     private WriteOptions writeOptions;
@@ -157,6 +161,7 @@ public class RocksDBStore extends AbstractStore implements AutoCloseable {
         this.rocksDB.close();
         if (this.storeFile != null && storeFile.exists()) {
             FileUtils.forceDelete(storeFile);
+            logger.info("close RocksDB success, delete path:{}", storeFile.getPath());
         }
     }
 

--- a/core/src/main/java/org/apache/rocketmq/streams/core/state/RocksDBStore.java
+++ b/core/src/main/java/org/apache/rocketmq/streams/core/state/RocksDBStore.java
@@ -17,8 +17,7 @@ package org.apache.rocketmq.streams.core.state;
  */
 
 
-import org.apache.rocketmq.common.UtilAll;
-import org.apache.rocketmq.remoting.common.RemotingUtil;
+import org.apache.commons.io.FileUtils;
 import org.apache.rocketmq.streams.core.function.ValueMapperAction;
 import org.apache.rocketmq.streams.core.window.WindowKey;
 import org.apache.rocketmq.streams.core.util.Pair;
@@ -32,6 +31,7 @@ import org.rocksdb.TtlDB;
 import org.rocksdb.WriteOptions;
 
 import java.io.File;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
@@ -41,27 +41,25 @@ public class RocksDBStore extends AbstractStore implements AutoCloseable {
     private RocksDB rocksDB;
     private WriteOptions writeOptions;
     private ReadOptions readOptions;
+    private File storeFile;
 
-    public RocksDBStore() {
-        createRocksDB();
+    public RocksDBStore(String path) {
+        createRocksDB(path);
     }
 
-    private void createRocksDB() {
+    private void createRocksDB(String path) {
         try (final Options options = new Options().setCreateIfMissing(true)) {
 
             try {
-                String localAddress = RemotingUtil.getLocalAddress();
-                int pid = UtilAll.getPid();
+                String rocksdbFilePath = String.format("%s/%s", ROCKSDB_PATH, path);
 
-                String rocksdbFilePath = String.format("%s/%s/%s", ROCKSDB_PATH, localAddress, pid);
+                storeFile = new File(rocksdbFilePath);
 
-
-                File dir = new File(rocksdbFilePath);
-                if (dir.exists() && !dir.delete()) {
-                    throw new RuntimeException("before create rocksdb, delete exist path " + rocksdbFilePath + " error");
+                if (storeFile.exists()) {
+                    FileUtils.forceDelete(storeFile);
                 }
 
-                if (!dir.mkdirs()) {
+                if (!storeFile.mkdirs()) {
                     throw new RuntimeException("before create rocksdb,mkdir path " + rocksdbFilePath + " error");
                 }
 
@@ -72,6 +70,8 @@ public class RocksDBStore extends AbstractStore implements AutoCloseable {
                 writeOptions.setDisableWAL(true);
             } catch (RocksDBException e) {
                 throw new RuntimeException("create rocksdb error " + e.getMessage());
+            } catch (IOException e) {
+                throw new RuntimeException("delete rocksdb directory:" + ROCKSDB_PATH + "field.");
             }
         }
     }
@@ -155,11 +155,14 @@ public class RocksDBStore extends AbstractStore implements AutoCloseable {
 
     public void close() throws Exception {
         this.rocksDB.close();
+        if (this.storeFile != null && storeFile.exists()) {
+            FileUtils.forceDelete(storeFile);
+        }
     }
 
 
     public static void main(String[] args) throws Throwable {
-        RocksDBStore rocksDBStore = new RocksDBStore();
+        RocksDBStore rocksDBStore = new RocksDBStore("test");
 
         String key = "time@1668249210000@1668249195000";
         String key2 = "time@1668249210001@1668249195001";

--- a/core/src/test/java/org/apache/rocketmq/streams/core/state/RocksDBStoreTest.java
+++ b/core/src/test/java/org/apache/rocketmq/streams/core/state/RocksDBStoreTest.java
@@ -25,7 +25,7 @@ import java.util.List;
 
 public class RocksDBStoreTest {
     public static void main(String[] args) throws Throwable {
-        RocksDBStore rocksDBStore = new RocksDBStore();
+        RocksDBStore rocksDBStore = new RocksDBStore("test");
 
 //        String key = "time@1668249210000@1668249195000";
 //        String key2 = "ewwwwe@1668249600481@1";


### PR DESCRIPTION
1. use the name of thread as rocksdb path;
2. clean the temporary data of rocksdb in local;
3. make WorkerThread shutdown method idempotent;

close #257